### PR TITLE
update ecommerce spec syntax to v2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -121,7 +121,7 @@ FacebookCustomAudiences.prototype.productAdded = function(track) {
  */
 
 FacebookCustomAudiences.prototype.orderCompleted = function(track) {
-  var content_ids = reduce(track.products() || [], [], function(ret, product) {
+  var content_ids = foldl(function(ret, product) {
     var id = product.id || product.sku || '';
     ret.push(id);
     return ret;

--- a/lib/index.js
+++ b/lib/index.js
@@ -64,13 +64,13 @@ FacebookCustomAudiences.prototype.track = function(track) {
 };
 
 /**
- * Viewed product category.
+ * Product list viewed.
  *
  * @api private
  * @param {Track} track category
  */
 
-FacebookCustomAudiences.prototype.viewedProductCategory = function(track) {
+FacebookCustomAudiences.prototype.productListViewed = function(track) {
   push('track', 'ViewContent', {
     content_ids: [String(track.category() || '')],
     content_type: 'product_group'
@@ -78,13 +78,13 @@ FacebookCustomAudiences.prototype.viewedProductCategory = function(track) {
 };
 
 /**
- * Viewed product.
+ * Product viewed.
  *
  * @api private
  * @param {Track} track
  */
 
-FacebookCustomAudiences.prototype.viewedProduct = function(track) {
+FacebookCustomAudiences.prototype.productViewed = function(track) {
   push('track', 'ViewContent', {
     content_ids: [String(track.id() || track.sku() || '')],
     content_type: 'product',
@@ -96,13 +96,13 @@ FacebookCustomAudiences.prototype.viewedProduct = function(track) {
 };
 
 /**
- * Added product.
+ * Product added.
  *
  * @api private
  * @param {Track} track
  */
 
-FacebookCustomAudiences.prototype.addedProduct = function(track) {
+FacebookCustomAudiences.prototype.productAdded = function(track) {
   push('track', 'AddToCart', {
     content_ids: [String(track.id() || track.sku() || '')],
     content_type: 'product',
@@ -114,14 +114,14 @@ FacebookCustomAudiences.prototype.addedProduct = function(track) {
 };
 
 /**
- * Completed Order.
+ * Order Completed.
  *
  * @api private
  * @param {Track} track
  */
 
-FacebookCustomAudiences.prototype.completedOrder = function(track) {
-  var content_ids = foldl(function(ret, product) {
+FacebookCustomAudiences.prototype.orderCompleted = function(track) {
+  var content_ids = reduce(track.products() || [], [], function(ret, product) {
     var id = product.id || product.sku || '';
     ret.push(id);
     return ret;

--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
   "homepage": "https://github.com/segment-integrations/analytics.js-integration-facebook-custom-audiences#readme",
   "dependencies": {
     "@ndhoule/foldl": "^2.0.1",
-    "@segment/analytics.js-integration": "^2.1.0",
+    "@segment/analytics.js-integration": "^3.1.0",
     "global-queue": "^1.0.1"
   },
   "devDependencies": {
     "@segment/analytics.js-core": "^3.0.0",
-    "@segment/analytics.js-integration-tester": "^2.0.0",
+    "@segment/analytics.js-integration-tester": "^3.0.0",
     "@segment/clear-env": "^2.0.0",
     "@segment/eslint-config": "^3.1.1",
     "browserify": "^13.0.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -99,16 +99,16 @@ describe('Facebook Custom Audiences', function() {
         }]);
       });
 
-      it('should send ecommerce event - Viewed Product Category', function() {
-        analytics.track('Viewed Product Category', { category: 'Games' });
+      it('should send ecommerce event - Product List Viewed', function() {
+        analytics.track('Product List Viewed', { category: 'Games' });
         analytics.called(window._fbq.push, ['track', 'ViewContent', {
           content_ids: ['Games'],
           content_type: 'product_group'
         }]);
       });
 
-      it('should send ecommerce event - Viewed Product', function() {
-        analytics.track('Viewed Product', {
+      it('should send ecommerce event - Product Viewed', function() {
+        analytics.track('Product Viewed', {
           id: '507f1f77bcf86cd799439011',
           currency: 'USD',
           value: 0.50,
@@ -129,7 +129,7 @@ describe('Facebook Custom Audiences', function() {
       });
 
       it('should send ecommerce event - Adding to Cart', function() {
-        analytics.track('Added Product', {
+        analytics.track('Product Added', {
           id: '507f1f77bcf86cd799439011',
           currency: 'USD',
           value: 0.50,
@@ -150,7 +150,7 @@ describe('Facebook Custom Audiences', function() {
       });
 
       it('should send ecommerce event - Completing an Order', function() {
-        analytics.track('Completed Order', {
+        analytics.track('Order Completed', {
           products: [
             { id: '507f1f77bcf86cd799439011' },
             { id: '505bd76785ebb509fc183733' }


### PR DESCRIPTION
This PR changes the ecommerce V1 syntax Action + Object to the new V2 syntax, Object + Action.

This PR will be waiting on a few blockers, a refactor of the Analytics-Events repo to be more concise and readable as we add more events to our spec and for similar changes to be made to all other integrations currently using V1 syntax.

Tests are failing because it isn't properly aliasing against the new spec'd events. These tests will need to pass, dependent on a new version of Analytics Events and Analytics.js-Private before being merged.
