### PR TITLE
look up revenue

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -92,7 +92,7 @@ FacebookCustomAudiences.prototype.productViewed = function(track) {
     content_name: String(track.name()),
     content_category: String(track.category()),
     currency: String(track.currency()),
-    value: Number(track.value())
+    value: Number(track.revenue() || track.value())
   });
 };
 


### PR DESCRIPTION
@sperand-io @f2prateek 

not sure why this is only looking up value. The FB pixel integration only looks up revenue. I think we should look both these up because otherwise, we'll get bunch of `NaN`
